### PR TITLE
added property rowId to getRow(s) method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release Notes
 
+## 1.9.1
+
+* added property `rowId` to methods `getRow` and `getRows` so it can be used for further manipulation like updates/deletions/etc.
+
 ## 1.9.0
 
 * added method `convertColumnToMultilanguage` and `convertColumnToSinglelanguage` to `Table`

--- a/docs/ColumnBuilder.html
+++ b/docs/ColumnBuilder.html
@@ -65,7 +65,7 @@
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="index.js.html">index.js</a>, <a href="index.js.html#line563">line 563</a>
+        <a href="index.js.html">index.js</a>, <a href="index.js.html#line576">line 576</a>
     </li></ul></dd>
     
 
@@ -235,7 +235,7 @@
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="index.js.html">index.js</a>, <a href="index.js.html#line581">line 581</a>
+        <a href="index.js.html">index.js</a>, <a href="index.js.html#line594">line 594</a>
     </li></ul></dd>
     
 
@@ -385,7 +385,7 @@
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="index.js.html">index.js</a>, <a href="index.js.html#line604">line 604</a>
+        <a href="index.js.html">index.js</a>, <a href="index.js.html#line617">line 617</a>
     </li></ul></dd>
     
 
@@ -544,7 +544,7 @@
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="index.js.html">index.js</a>, <a href="index.js.html#line594">line 594</a>
+        <a href="index.js.html">index.js</a>, <a href="index.js.html#line607">line 607</a>
     </li></ul></dd>
     
 
@@ -703,7 +703,7 @@
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="index.js.html">index.js</a>, <a href="index.js.html#line729">line 729</a>
+        <a href="index.js.html">index.js</a>, <a href="index.js.html#line742">line 742</a>
     </li></ul></dd>
     
 
@@ -850,7 +850,7 @@
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="index.js.html">index.js</a>, <a href="index.js.html#line710">line 710</a>
+        <a href="index.js.html">index.js</a>, <a href="index.js.html#line723">line 723</a>
     </li></ul></dd>
     
 
@@ -997,7 +997,7 @@
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="index.js.html">index.js</a>, <a href="index.js.html#line666">line 666</a>
+        <a href="index.js.html">index.js</a>, <a href="index.js.html#line679">line 679</a>
     </li></ul></dd>
     
 
@@ -1164,7 +1164,7 @@
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="index.js.html">index.js</a>, <a href="index.js.html#line640">line 640</a>
+        <a href="index.js.html">index.js</a>, <a href="index.js.html#line653">line 653</a>
     </li></ul></dd>
     
 
@@ -1354,7 +1354,7 @@
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="index.js.html">index.js</a>, <a href="index.js.html#line686">line 686</a>
+        <a href="index.js.html">index.js</a>, <a href="index.js.html#line699">line 699</a>
     </li></ul></dd>
     
 
@@ -1504,7 +1504,7 @@
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="index.js.html">index.js</a>, <a href="index.js.html#line624">line 624</a>
+        <a href="index.js.html">index.js</a>, <a href="index.js.html#line637">line 637</a>
     </li></ul></dd>
     
 
@@ -1671,7 +1671,7 @@
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="index.js.html">index.js</a>, <a href="index.js.html#line614">line 614</a>
+        <a href="index.js.html">index.js</a>, <a href="index.js.html#line627">line 627</a>
     </li></ul></dd>
     
 
@@ -1818,7 +1818,7 @@
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="index.js.html">index.js</a>, <a href="index.js.html#line676">line 676</a>
+        <a href="index.js.html">index.js</a>, <a href="index.js.html#line689">line 689</a>
     </li></ul></dd>
     
 
@@ -1968,7 +1968,7 @@
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="index.js.html">index.js</a>, <a href="index.js.html#line818">line 818</a>
+        <a href="index.js.html">index.js</a>, <a href="index.js.html#line831">line 831</a>
     </li></ul></dd>
     
 
@@ -2066,7 +2066,7 @@
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="index.js.html">index.js</a>, <a href="index.js.html#line780">line 780</a>
+        <a href="index.js.html">index.js</a>, <a href="index.js.html#line793">line 793</a>
     </li></ul></dd>
     
 
@@ -2225,7 +2225,7 @@
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="index.js.html">index.js</a>, <a href="index.js.html#line760">line 760</a>
+        <a href="index.js.html">index.js</a>, <a href="index.js.html#line773">line 773</a>
     </li></ul></dd>
     
 
@@ -2384,7 +2384,7 @@
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="index.js.html">index.js</a>, <a href="index.js.html#line744">line 744</a>
+        <a href="index.js.html">index.js</a>, <a href="index.js.html#line757">line 757</a>
     </li></ul></dd>
     
 
@@ -2531,7 +2531,7 @@
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="index.js.html">index.js</a>, <a href="index.js.html#line800">line 800</a>
+        <a href="index.js.html">index.js</a>, <a href="index.js.html#line813">line 813</a>
     </li></ul></dd>
     
 

--- a/docs/ConstraintBuilder.html
+++ b/docs/ConstraintBuilder.html
@@ -65,7 +65,7 @@
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="index.js.html">index.js</a>, <a href="index.js.html#line849">line 849</a>
+        <a href="index.js.html">index.js</a>, <a href="index.js.html#line862">line 862</a>
     </li></ul></dd>
     
 
@@ -163,7 +163,7 @@
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="index.js.html">index.js</a>, <a href="index.js.html#line880">line 880</a>
+        <a href="index.js.html">index.js</a>, <a href="index.js.html#line893">line 893</a>
     </li></ul></dd>
     
 
@@ -333,7 +333,7 @@
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="index.js.html">index.js</a>, <a href="index.js.html#line870">line 870</a>
+        <a href="index.js.html">index.js</a>, <a href="index.js.html#line883">line 883</a>
     </li></ul></dd>
     
 
@@ -431,7 +431,7 @@
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="index.js.html">index.js</a>, <a href="index.js.html#line862">line 862</a>
+        <a href="index.js.html">index.js</a>, <a href="index.js.html#line875">line 875</a>
     </li></ul></dd>
     
 
@@ -529,7 +529,7 @@
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="index.js.html">index.js</a>, <a href="index.js.html#line854">line 854</a>
+        <a href="index.js.html">index.js</a>, <a href="index.js.html#line867">line 867</a>
     </li></ul></dd>
     
 
@@ -627,7 +627,7 @@
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="index.js.html">index.js</a>, <a href="index.js.html#line894">line 894</a>
+        <a href="index.js.html">index.js</a>, <a href="index.js.html#line907">line 907</a>
     </li></ul></dd>
     
 

--- a/docs/Table.html
+++ b/docs/Table.html
@@ -235,7 +235,7 @@
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="index.js.html">index.js</a>, <a href="index.js.html#line381">line 381</a>
+        <a href="index.js.html">index.js</a>, <a href="index.js.html#line394">line 394</a>
     </li></ul></dd>
     
 
@@ -391,7 +391,7 @@
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="index.js.html">index.js</a>, <a href="index.js.html#line443">line 443</a>
+        <a href="index.js.html">index.js</a>, <a href="index.js.html#line456">line 456</a>
     </li></ul></dd>
     
 
@@ -547,7 +547,7 @@
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="index.js.html">index.js</a>, <a href="index.js.html#line268">line 268</a>
+        <a href="index.js.html">index.js</a>, <a href="index.js.html#line281">line 281</a>
     </li></ul></dd>
     
 
@@ -698,7 +698,7 @@
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="index.js.html">index.js</a>, <a href="index.js.html#line215">line 215</a>
+        <a href="index.js.html">index.js</a>, <a href="index.js.html#line228">line 228</a>
     </li></ul></dd>
     
 
@@ -845,7 +845,7 @@
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="index.js.html">index.js</a>, <a href="index.js.html#line332">line 332</a>
+        <a href="index.js.html">index.js</a>, <a href="index.js.html#line345">line 345</a>
     </li></ul></dd>
     
 
@@ -947,7 +947,7 @@
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="index.js.html">index.js</a>, <a href="index.js.html#line321">line 321</a>
+        <a href="index.js.html">index.js</a>, <a href="index.js.html#line334">line 334</a>
     </li></ul></dd>
     
 
@@ -1098,7 +1098,7 @@
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="index.js.html">index.js</a>, <a href="index.js.html#line344">line 344</a>
+        <a href="index.js.html">index.js</a>, <a href="index.js.html#line357">line 357</a>
     </li></ul></dd>
     
 
@@ -1272,7 +1272,7 @@
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="index.js.html">index.js</a>, <a href="index.js.html#line247">line 247</a>
+        <a href="index.js.html">index.js</a>, <a href="index.js.html#line260">line 260</a>
     </li></ul></dd>
     
 
@@ -1563,7 +1563,7 @@
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="index.js.html">index.js</a>, <a href="index.js.html#line196">line 196</a>
+        <a href="index.js.html">index.js</a>, <a href="index.js.html#line209">line 209</a>
     </li></ul></dd>
     
 
@@ -1695,7 +1695,7 @@
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="index.js.html">index.js</a>, <a href="index.js.html#line175">line 175</a>
+        <a href="index.js.html">index.js</a>, <a href="index.js.html#line185">line 185</a>
     </li></ul></dd>
     
 
@@ -1736,6 +1736,9 @@
 
 <div class="description">
     Returns a single row object zipped with column names for this Table.
+
+The `rowId` property represents the row ID (PK) of the database,
+so this value can be reused for updates/deletions/etc.
 </div>
 
 
@@ -1850,7 +1853,7 @@
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="index.js.html">index.js</a>, <a href="index.js.html#line159">line 159</a>
+        <a href="index.js.html">index.js</a>, <a href="index.js.html#line162">line 162</a>
     </li></ul></dd>
     
 
@@ -1891,6 +1894,9 @@
 
 <div class="description">
     Returns an array of row objects zipped with column names for this Table.
+
+The `rowId` property represents the row ID (PK) of the database,
+so this value can be reused for updates/deletions/etc.
 </div>
 
 

--- a/docs/TableBuilder.html
+++ b/docs/TableBuilder.html
@@ -65,7 +65,7 @@
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="index.js.html">index.js</a>, <a href="index.js.html#line497">line 497</a>
+        <a href="index.js.html">index.js</a>, <a href="index.js.html#line510">line 510</a>
     </li></ul></dd>
     
 
@@ -238,7 +238,7 @@
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="index.js.html">index.js</a>, <a href="index.js.html#line553">line 553</a>
+        <a href="index.js.html">index.js</a>, <a href="index.js.html#line566">line 566</a>
     </li></ul></dd>
     
 
@@ -336,7 +336,7 @@
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="index.js.html">index.js</a>, <a href="index.js.html#line520">line 520</a>
+        <a href="index.js.html">index.js</a>, <a href="index.js.html#line533">line 533</a>
     </li></ul></dd>
     
 
@@ -495,7 +495,7 @@
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="index.js.html">index.js</a>, <a href="index.js.html#line540">line 540</a>
+        <a href="index.js.html">index.js</a>, <a href="index.js.html#line553">line 553</a>
     </li></ul></dd>
     
 
@@ -642,7 +642,7 @@
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="index.js.html">index.js</a>, <a href="index.js.html#line530">line 530</a>
+        <a href="index.js.html">index.js</a>, <a href="index.js.html#line543">line 543</a>
     </li></ul></dd>
     
 

--- a/docs/global.html
+++ b/docs/global.html
@@ -466,7 +466,7 @@
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="index.js.html">index.js</a>, <a href="index.js.html#line838">line 838</a>
+        <a href="index.js.html">index.js</a>, <a href="index.js.html#line851">line 851</a>
     </li></ul></dd>
     
 
@@ -535,7 +535,7 @@
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="index.js.html">index.js</a>, <a href="index.js.html#line842">line 842</a>
+        <a href="index.js.html">index.js</a>, <a href="index.js.html#line855">line 855</a>
     </li></ul></dd>
     
 

--- a/docs/index.js.html
+++ b/docs/index.js.html
@@ -193,6 +193,9 @@ function grudStructorizer(baseUrl, options) {
     /**
      * Returns an array of row objects zipped with column names for this Table.
      *
+     * The `rowId` property represents the row ID (PK) of the database,
+     * so this value can be reused for updates/deletions/etc.
+     *
      * @returns {Array.&lt;object>} array row objects
      */
     getRows() {
@@ -201,12 +204,19 @@ function grudStructorizer(baseUrl, options) {
       }
       return _.map(
         this.rows,
-        (row) => _.zipObject(_.map(this.columns, "name"), row.values)
+        (row) => {
+          const obj = _.zipObject(_.map(this.columns, "name"), row.values);
+          obj.rowId = row.id;
+          return obj;
+        }
       );
     }
 
     /**
      * Returns a single row object zipped with column names for this Table.
+     *
+     * The `rowId` property represents the row ID (PK) of the database,
+     * so this value can be reused for updates/deletions/etc.
      *
      * @param id {number}
      * @returns {Object} row object
@@ -225,7 +235,10 @@ function grudStructorizer(baseUrl, options) {
         throw new Error("No row found for id '" + id + "'");
       }
 
-      return _.zipObject(_.map(this.columns, "name"), foundRow.values);
+      const obj = _.zipObject(_.map(this.columns, "name"), foundRow.values);
+      obj.rowId = foundRow.id;
+
+      return obj;
     }
 
     /**

--- a/lib/index.js
+++ b/lib/index.js
@@ -185,6 +185,9 @@ function grudStructorizer(baseUrl, options) {
       /**
        * Returns an array of row objects zipped with column names for this Table.
        *
+       * The `rowId` property represents the row ID (PK) of the database,
+       * so this value can be reused for updates/deletions/etc.
+       *
        * @returns {Array.<object>} array row objects
        */
 
@@ -197,12 +200,17 @@ function grudStructorizer(baseUrl, options) {
           throw new Error("Fetch table and rows first");
         }
         return _.map(this.rows, function (row) {
-          return _.zipObject(_.map(_this.columns, "name"), row.values);
+          var obj = _.zipObject(_.map(_this.columns, "name"), row.values);
+          obj.rowId = row.id;
+          return obj;
         });
       }
 
       /**
        * Returns a single row object zipped with column names for this Table.
+       *
+       * The `rowId` property represents the row ID (PK) of the database,
+       * so this value can be reused for updates/deletions/etc.
        *
        * @param id {number}
        * @returns {Object} row object
@@ -226,7 +234,10 @@ function grudStructorizer(baseUrl, options) {
           throw new Error("No row found for id '" + id + "'");
         }
 
-        return _.zipObject(_.map(this.columns, "name"), foundRow.values);
+        var obj = _.zipObject(_.map(this.columns, "name"), foundRow.values);
+        obj.rowId = foundRow.id;
+
+        return obj;
       }
 
       /**

--- a/lib/types.d.ts
+++ b/lib/types.d.ts
@@ -117,12 +117,16 @@ declare class Table {
 
     /**
      * Returns an array of row objects zipped with column names for this Table.
+     * The `rowId` property represents the row ID (PK) of the database,
+     * so this value can be reused for updates/deletions/etc.
      * @returns {Array.<object>} array row objects
      */
     getRows(): any[];
 
     /**
      * Returns a single row object zipped with column names for this Table.
+     * The `rowId` property represents the row ID (PK) of the database,
+     * so this value can be reused for updates/deletions/etc.
      * @param id {number}
      * @returns {Object} row object
      */

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "grud-structorizer",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grud-structorizer",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "description": "Core library for building schemas",
   "main": "lib/index.js",
   "types": "./lib/types.d.ts",

--- a/src/__tests__/table.spec.js
+++ b/src/__tests__/table.spec.js
@@ -41,15 +41,15 @@ describe("Table", () => {
     expect(values).toEqual([42, "someText"]);
   });
 
-  it("should contain a array of three row ojects", () => {
+  it("should contain an array of three row ojects", () => {
     expect(defaultTable.getRows().length).toEqual(3);
-    expect(defaultTable.getRows()[0]).toEqual({ "a_number": 11, "name": "black", "hexcode": "000000" });
-    expect(defaultTable.getRows()[1]).toEqual({ "a_number": 22, "name": "white", "hexcode": "FFFFFF" });
-    expect(defaultTable.getRows()[2]).toEqual({ "a_number": 44, "name": "red", "hexcode": "ba2a29" });
+    expect(defaultTable.getRows()[0]).toEqual({ "a_number": 11, "name": "black", "hexcode": "000000", "rowId": 1 });
+    expect(defaultTable.getRows()[1]).toEqual({ "a_number": 22, "name": "white", "hexcode": "FFFFFF", "rowId": 2 });
+    expect(defaultTable.getRows()[2]).toEqual({ "a_number": 44, "name": "red", "hexcode": "ba2a29", "rowId": 4 });
   });
 
   it("should contain a single row ojects", () => {
-    expect(defaultTable.getRow(2)).toEqual({ "a_number": 22, "name": "white", "hexcode": "FFFFFF" });
+    expect(defaultTable.getRow(2)).toEqual({ "a_number": 22, "name": "white", "hexcode": "FFFFFF", "rowId": 2 });
   });
 
   it("should throw row for id does not exist", () => {

--- a/src/index.js
+++ b/src/index.js
@@ -154,6 +154,9 @@ function grudStructorizer(baseUrl, options) {
     /**
      * Returns an array of row objects zipped with column names for this Table.
      *
+     * The `rowId` property represents the row ID (PK) of the database,
+     * so this value can be reused for updates/deletions/etc.
+     *
      * @returns {Array.<object>} array row objects
      */
     getRows() {
@@ -162,12 +165,19 @@ function grudStructorizer(baseUrl, options) {
       }
       return _.map(
         this.rows,
-        (row) => _.zipObject(_.map(this.columns, "name"), row.values)
+        (row) => {
+          const obj = _.zipObject(_.map(this.columns, "name"), row.values);
+          obj.rowId = row.id;
+          return obj;
+        }
       );
     }
 
     /**
      * Returns a single row object zipped with column names for this Table.
+     *
+     * The `rowId` property represents the row ID (PK) of the database,
+     * so this value can be reused for updates/deletions/etc.
      *
      * @param id {number}
      * @returns {Object} row object
@@ -186,7 +196,10 @@ function grudStructorizer(baseUrl, options) {
         throw new Error("No row found for id '" + id + "'");
       }
 
-      return _.zipObject(_.map(this.columns, "name"), foundRow.values);
+      const obj = _.zipObject(_.map(this.columns, "name"), foundRow.values);
+      obj.rowId = foundRow.id;
+
+      return obj;
     }
 
     /**


### PR DESCRIPTION
Methods getRow() and getRows() is quite useless without `rowId`. If you want to change or delete rows you need a PK